### PR TITLE
working bump with v4 endpoints

### DIFF
--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -53,7 +53,7 @@ def check_main(api_key, call_id):
 # Takes in start params and returns the full server json response
 def start_api(api_key, model_key, model_inputs, start_only=False):
     global endpoint
-    route_start = "start/v3/"
+    route_start = "start/v4/"
     url_start = endpoint + route_start
 
     payload = {
@@ -83,7 +83,7 @@ def start_api(api_key, model_key, model_inputs, start_only=False):
 # Takes in call_id to return the server response
 def check_api(api_key, call_id):
     global endpoint
-    route_check = "check/v3/"
+    route_check = "check/v4/"
     url_check = endpoint + route_check
     # Poll server for completed task
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
   name = 'banana_dev',
   packages = ['banana_dev'],
-  version = '3.0.1',
+  version = '4.0.0',
   license='MIT',
   description = 'The banana package is a python client to interact with your machine learning models hosted on Banana',   # Give a short description about your library
   long_description=long_description,


### PR DESCRIPTION
# Why

We've depricated parts of the backend in an attempt to simplify it of backward compatibility, therefore we're making fresh endpoints on a new major version to make sure that pre-serverless users of our backend have a stable 3.x.x release now that we're on 4.x.x

The API itself is not changing, so no need for users to rewrite their code. We're just deprecating old parts of the backend.

# Testing

Tested end-to-end with recently deployed v4 endpoints on backend, everything works as expected.