### PR TITLE
loosened requirements on requests library to then loosen urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,31 +6,29 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 setup(
-  name = 'banana_dev',
-  packages = ['banana_dev'],
-  version = '4.0.0',
-  license='MIT',
-  description = 'The banana package is a python client to interact with your machine learning models hosted on Banana',   # Give a short description about your library
-  long_description=long_description,
-  long_description_content_type='text/markdown',
-  author = 'Erik Dunteman',
-  author_email = 'erik@banana.dev',
-  url = 'https://www.banana.dev',
-  keywords = ['Banana client', 'API wrapper', 'Banana', 'SDK'],
-  setup_requires = ['wheel'],
-  install_requires=[
-    "certifi==2021.10.8",
-    "charset-normalizer==2.0.7",
-    "idna==3.3",
-    "requests==2.26.0",
-    "urllib3==1.26.7",
-  ],
-  classifiers=[
-    'Development Status :: 5 - Production/Stable',      # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
-    'Intended Audience :: Developers',
-    'Topic :: Software Development :: Build Tools',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-  ],
+    name='banana_dev',
+    packages=['banana_dev'],
+    version='4.0.1',
+    license='MIT',
+    # Give a short description about your library
+    description='The banana package is a python client to interact with your machine learning models hosted on Banana',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author='Erik Dunteman',
+    author_email='erik@banana.dev',
+    url='https://www.banana.dev',
+    keywords=['Banana client', 'API wrapper', 'Banana', 'SDK'],
+    setup_requires=['wheel'],
+    install_requires=[
+        "requests>=2.26.0,<3.0.0",
+    ],
+    classifiers=[
+        # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
 )


### PR DESCRIPTION
# What is this?
This PR removes the hard version requirements on the pip dependencies, and reduces requirements down to just the requests library

# Why?
https://github.com/bananaml/banana-python-sdk/issues/5

# How did you test to ensure no regressions?
- I ran end-to-end tests on a Carrot model, using these version specs -> tests pass
- I installed sentry-sdk per issue 5 -> verified it installs
- I've verified that [requests follows SemVer](https://requests.readthedocs.io/en/latest/community/release-process/)

# If this is a new feature what is one way you can make this break?
N/A
