### PR TITLE
added BANANA_SERVER env var for pointing at direct server endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,29 @@
 ### Getting Started
 
 Install via pip
-`pip3 install banana-dev`
+```bash
+pip3 install banana-dev
+```
 
-Get your API Key
-- [Sign in / log in here](https://app.banana.dev)
+If integration testing against a local Potassium server:
+```bash
+export BANANA_SERVER=local
+```
+to call `http://localhost:8000/` directly. Be sure to unset in prod!
 
-Run:
+
+If deploying to prod:
+[Sign in / log in here](https://app.banana.dev) to get your API and Model Keys
+
+### Run:
+
 ```python
 import banana_dev as banana
 
-api_key = "demo" # "YOUR_API_KEY"
-model_key = "carrot" # "YOUR_MODEL_KEY"
+# Your credentials. Can be empty strings if testing against a local server.
+api_key = "demo" # YOUR_API_KEY
+model_key = "carrot" # YOUR_MODEL_KEY
+
 model_inputs = {
     # a json specific to your model. For example:
     "imageURL":  "https://demo-images-banana.s3.us-west-1.amazonaws.com/image2.jpg"

--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -26,7 +26,7 @@ if 'BANANA_SERVER' in os.environ:
 # ___________________________________
 
 def run_main(api_key, model_key, model_inputs):
-    # run against self-hosted potassiun server if being ran
+    # run against self-hosted potassiun server if BANANA_SERVER was set
     if is_direct:
         return run_direct(model_inputs)
 

--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -18,9 +18,9 @@ direct_call_endpoint = "http://localhost:8000/"
 is_direct = False
 if 'BANANA_SERVER' in os.environ:
     is_direct = True    
-    print("Routing calls directly to server hosted at", direct_call_endpoint)
     if os.getenv("BANANA_SERVER") != "local":
         direct_call_endpoint = os.getenv("BANANA_SERVER")
+    print("Routing calls directly to server hosted at", direct_call_endpoint)
 
 # THE MAIN FUNCTIONS
 # ___________________________________

--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -14,11 +14,22 @@ if 'BANANA_URL' in os.environ:
         endpoint = os.environ['BANANA_URL']
     print("Hitting endpoint:", endpoint)
 
+direct_call_endpoint = "http://localhost:8000/"
+is_direct = False
+if 'BANANA_SERVER' in os.environ:
+    is_direct = True    
+    print("Routing calls directly to server hosted at", direct_call_endpoint)
+    if os.getenv("BANANA_SERVER") != "local":
+        direct_call_endpoint = os.getenv("BANANA_SERVER")
+
 # THE MAIN FUNCTIONS
 # ___________________________________
 
-
 def run_main(api_key, model_key, model_inputs):
+    # run against self-hosted potassiun server if being ran
+    if is_direct:
+        return run_direct(model_inputs)
+
     result = start_api(api_key, model_key, model_inputs)
 
     # likely we get results on first call
@@ -50,6 +61,26 @@ def check_main(api_key, call_id):
 # THE API CALLING FUNCTIONS
 # ________________________
 
+def run_direct(model_inputs):
+    global direct_call_endpoint
+    response = requests.post(direct_call_endpoint, json=model_inputs)
+    if response.status_code != 200:
+        raise Exception("server error: status code {}".format(response.status_code))
+    try:
+        out = response.json()
+    except:
+        raise Exception("server error: returned invalid json")
+    
+    # We must match the same API as the prod inference server,
+    # so wrap direct API's results in same response shape
+    return {
+        "id": str(uuid4()),
+        "message": "",
+        "created": str(int(time.time())),
+        "apiVersion": "DIRECT",
+        "modelOutputs": [out]
+    }
+
 # Takes in start params and returns the full server json response
 def start_api(api_key, model_key, model_inputs, start_only=False):
     global endpoint
@@ -69,7 +100,6 @@ def start_api(api_key, model_key, model_inputs, start_only=False):
 
     if response.status_code != 200:
         raise Exception("server error: status code {}".format(response.status_code))
-
     try:
         out = response.json()
     except:

--- a/banana_dev/generics.py
+++ b/banana_dev/generics.py
@@ -65,7 +65,7 @@ def run_direct(model_inputs):
     global direct_call_endpoint
     response = requests.post(direct_call_endpoint, json=model_inputs)
     if response.status_code != 200:
-        raise Exception("server error: status code {}".format(response.status_code))
+        raise Exception("server error: status code: {}\content: {}".format(response.status_code, response.content))
     try:
         out = response.json()
     except:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='banana_dev',
     packages=['banana_dev'],
-    version='4.0.1',
+    version='4.0.2',
     license='MIT',
     # Give a short description about your library
     description='The banana package is a python client to interact with your machine learning models hosted on Banana',


### PR DESCRIPTION
# What is this?
Adds BANANA_SERVER env var, which points to local dev servers or remote urls and calls that directly with a single POST request, rather than routing through our middleware.

# Why?
1. to allow for testing locally with the SDK
2. to prep for an upcoming bananav2 infra change where you call a URL directly

# How did you test to ensure no regressions?
Ran it with and without this BANANA_SERVER on a prod model and local hosted model, works

# If this is a new feature what is one way you can make this break?
A user could theoretically already have a BANANA_SERVER env var in prod for whatever reason, so we're at risk of that causing issues.
