### PR TITLE
removed use_replica argument

### DIFF
--- a/banana_dev/client.py
+++ b/banana_dev/client.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Tuple
 import requests, time
 
 class ClientException(Exception):
@@ -12,18 +12,18 @@ class ClientException(Exception):
         super().__init__(self.message)
 
 class Client():
+    "The Banana client class is for interracting with a specific model on Banana."
     def __init__(self, api_key, model_key, url, verbose = True):
         self.api_key = api_key
         self.model_key = model_key
         self.url = url
         self.verbose = verbose
 
-    def call(self, route: str, json: dict = {}, headers: dict = {}, use_replica: Union[str, None] = None, retry=True, retry_timeout = 300):
+    "Call a route on the Banana server with a POST request"
+    def call(self, route: str, json: dict = {}, headers: dict = {}, retry=True, retry_timeout = 300) -> Tuple[dict, dict]:
         headers["Content-Type"] = "application/json"
         headers['X-BANANA-API-KEY'] = self.api_key
         headers['X-BANANA-MODEL-KEY'] = self.model_key
-        if use_replica != None:
-            headers["X-USE-REPLICA"] = use_replica
         endpoint = self.url.rstrip("/") + "/" + route.lstrip("/")
 
         backoff_interval = 0.1 # seed for exponential backoff

--- a/setup_staging.py
+++ b/setup_staging.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='banana_dev_staging',
     packages=['banana_dev_staging'],
-    version='5.0.0',
+    version='5.0.1',
     license='MIT',
     # Give a short description about your library
     description='The banana package is a python client to interact with your Potassium servers hosted on Banana',


### PR DESCRIPTION
# What is this?
Removes the use_replica argument

# Why?
Users depending on specific replicas to hold data was causing unnecessary complexity. We're instead expanding the potassium Store feature

# How did you test it works without regressions?
Ran calls to production v2 models using modified sdk

# If this is a new feature what may a critical error (P0) look like? 
This is a breaking change, though very few users are on v2 and none are using this feature as far as we know
