### PR TITLE
maximum 3s backoff interval

### DIFF
--- a/banana_dev/client.py
+++ b/banana_dev/client.py
@@ -41,7 +41,7 @@ class Client():
                 if self.verbose:
                     print("Retrying...")
             
-            backoff_interval *= 2
+            backoff_interval = min(backoff_interval*2, 3)
             
             res = requests.post(endpoint, json=json, headers=headers)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='banana_dev',
     packages=['banana_dev'],
-    version='5.0.0',
+    version='5.0.1',
     license='MIT',
     # Give a short description about your library
     description='The banana package is a python client to interact with your machine learning models hosted on Banana',


### PR DESCRIPTION
# What is this?
adds a limit to the retry backoff

# Why?
replicas were getting cold during the backoff time, which added much needless latency

# How did you test it works without  regressions?
ran tests on js sdk for same logic, single sanity call here

# If this is a new feature what may a critical error (P0) look like? 
too many sdks retrying could ddos our backend