### PR TITLE
Warmup endpoint support

### DIFF
--- a/banana_dev/client.py
+++ b/banana_dev/client.py
@@ -19,6 +19,10 @@ class Client():
         self.url = url
         self.verbosity = verbosity
 
+    def warmup(self) -> Tuple[dict, dict]:
+        "Warm up the Potassium server"
+        return self.call("/_k/warmup", json={}, headers={}, retry=False)
+
     "Call a route on the Banana server with a POST request"
     def call(self, route: str, json: dict = {}, headers: dict = {}, retry=True, retry_timeout = 300) -> Tuple[dict, dict]:
         headers["Content-Type"] = "application/json"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='banana_dev',
     packages=['banana_dev'],
-    version='6.0.0',
+    version='6.1.0',
     license='MIT',
     # Give a short description about your library
     description='The banana package is a python client to interact with your machine learning models hosted on Banana',


### PR DESCRIPTION
# What is this?

Allows calling the Potassium "warmup" endpoint from the SDK.

Fixes BAN-392

# Why?

It's now natively in Potassium, so let's make it easy to use in the SDK rather than having to manually call the model's internal API endpoint.

# How did you test it works without  regressions?

<img width="1014" alt="image" src="https://github.com/bananaml/banana-python-sdk/assets/6206742/3ecf4005-8d63-4635-afc2-a3bbf3ca0bce">

<img width="1014" alt="image" src="https://github.com/bananaml/banana-python-sdk/assets/6206742/07a7e84b-b6cd-41be-91d6-3e6a587fb6e2">

<img width="1014" alt="image" src="https://github.com/bananaml/banana-python-sdk/assets/6206742/3331e285-c83b-4e98-ae7e-6ddd99915374">
