### PR TITLE
API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Tests
 test*
+tests
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Create some script
 from banana_dev import API
 
 api = API("11111111-1111-1111-1111-111111111111")
-projects = api.listProjects()
-print('list',projects)
+projects, status = api.listProjects()
+print('list',projects,status)
 
-project = api.getProject(projects["results"][0]["id"])
-print('get',project)
+project, status = api.getProject(projects["results"][0]["id"])
+print('get',project,status)
 
-updatedProject = api.updateProject(projects["results"][0]["id"], {"maxReplicas": 2})
-print('update',updatedProject)
+updatedProject, status = api.updateProject(projects["results"][0]["id"], {"maxReplicas": 2})
+print('update',updatedProject,status)
 ```
 
 Run it

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
 # Banana Python SDK
 
 Please see our usage docs in the official [Banana Documentation](https://docs.banana.dev/banana-docs/core-concepts/sdks/python)
+
+## Developing on the SDK
+
+Set up the environment and install the package in editable mode
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ./
+```
+
+Set up a test directory to play around with the changes
+```bash
+mkdir tests
+cd tests
+touch test.py
+```
+
+Create some script
+```python
+from banana_dev import API
+
+api = API("11111111-1111-1111-1111-111111111111")
+projects = api.listProjects()
+print('list',projects)
+
+project = api.getProject(projects["results"][0]["id"])
+print('get',project)
+
+updatedProject = api.updateProject(projects["results"][0]["id"], {"maxReplicas": 2})
+print('update',updatedProject)
+```
+
+Run it
+```bash
+python test.py
+```

--- a/banana_dev/__init__.py
+++ b/banana_dev/__init__.py
@@ -1,1 +1,2 @@
 from .client import Client
+from .api import API

--- a/banana_dev/api.py
+++ b/banana_dev/api.py
@@ -36,7 +36,4 @@ class API():
         elif method == "GET":
             res = requests.get(endpoint, params=data, headers=headers)
 
-        try:
-            return res.json(), res.status_code
-        except:
-            return {}, res.status_code
+        return res.json(), res.status_code

--- a/banana_dev/api.py
+++ b/banana_dev/api.py
@@ -6,20 +6,18 @@ API_BASE_URL = "https://api.banana.dev/v1"
 
 class API():
     "The Banana API class interacts with the Banana API."
-    def __init__(self, api_key, verbosity = "DEBUG"):
+    def __init__(self, api_key):
         self.api_key = api_key
-        self.verbosity = verbosity
 
     "Get the projects API client"
     def projects(self) -> "ProjectsAPI":
-        return ProjectsAPI(self.api_key, self.verbosity)
+        return ProjectsAPI(self.api_key)
 
 
 class ProjectsAPI():
     "The Banana Projects API class is for interacting with Banana's API for project automation."
-    def __init__(self, api_key, verbosity = "DEBUG"):
+    def __init__(self, api_key,):
         self.api_key = api_key
-        self.verbosity = verbosity
 
     "Get all projects under the team account"
     def list(self, route: str, json: dict = {}) -> Tuple[dict, dict]:

--- a/banana_dev/api.py
+++ b/banana_dev/api.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import requests
 
 
@@ -8,18 +9,18 @@ class API():
         self.api_key = api_key.strip()
 
     "Get all projects under the team account"
-    def listProjects(self, query: dict = {}) -> dict:
+    def listProjects(self, query: dict = {}) -> Tuple[dict, int]:
         return self.__call("GET", "projects", query)
 
     "Get a specific project by ID"
-    def getProject(self, project_id: str, query: dict = {}) -> dict:
+    def getProject(self, project_id: str, query: dict = {}) -> Tuple[dict, int]:
         return self.__call("GET", f"projects/{project_id}", query)
     
     "Update a project's settings"
-    def updateProject(self, project_id: str, json: dict = {}) -> dict:
+    def updateProject(self, project_id: str, json: dict = {}) -> Tuple[dict, int]:
         return self.__call("PUT", f"projects/{project_id}", json)
 
-    def __call(self, method: str, route: str, data: dict = {}) -> dict:
+    def __call(self, method: str, route: str, data: dict = {}) -> Tuple[dict, int]:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
@@ -36,6 +37,6 @@ class API():
             res = requests.get(endpoint, params=data, headers=headers)
 
         try:
-            return res.json()
+            return res.json(), res.status_code
         except:
-            return {}
+            return {}, res.status_code

--- a/banana_dev/api.py
+++ b/banana_dev/api.py
@@ -1,0 +1,54 @@
+from typing import Union, Tuple
+import requests
+
+API_BASE_URL = "https://api.banana.dev/v1"
+
+
+class API():
+    "The Banana API class interacts with the Banana API."
+    def __init__(self, api_key, verbosity = "DEBUG"):
+        self.api_key = api_key
+        self.verbosity = verbosity
+
+    "Get the projects API client"
+    def projects(self) -> "ProjectsAPI":
+        return ProjectsAPI(self.api_key, self.verbosity)
+
+
+class ProjectsAPI():
+    "The Banana Projects API class is for interacting with Banana's API for project automation."
+    def __init__(self, api_key, verbosity = "DEBUG"):
+        self.api_key = api_key
+        self.verbosity = verbosity
+
+    "Get all projects under the team account"
+    def list(self, route: str, json: dict = {}) -> Tuple[dict, dict]:
+        return self.__call("GET", route, json)
+
+    "Get a specific project by ID"
+    def get(self, project_id: str) -> Tuple[dict, dict]:
+        return self.__call("GET", f"projects/{project_id}")
+    
+    "Update a project's settings"
+    def update(self, project_id: str, json: dict = {}) -> Tuple[dict, dict]:
+        return self.__call("PUT", f"projects/{project_id}", json)
+
+    def __call(self, method: str, route: str, data: dict = {}) -> Tuple[dict, dict]:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-BANANA-API-KEY": self.api_key
+        }
+
+        endpoint = f"{API_BASE_URL}/{route}"
+
+        if method == "POST":
+            res = requests.post(endpoint, json=data, headers=headers)
+        elif method == "GET":
+            res = requests.get(endpoint, headers=headers)
+
+        meta = {"headers":res.headers}
+        try:
+            return res.json(), meta
+        except:
+            return {}, meta

--- a/banana_dev/api.py
+++ b/banana_dev/api.py
@@ -1,4 +1,3 @@
-from typing import Union, Tuple
 import requests
 
 
@@ -6,21 +5,21 @@ class API():
     "The Banana API class interacts with the Banana API."
     def __init__(self, api_key):
         self.base_url = "https://api.banana.dev/v1"
-        self.api_key = api_key
+        self.api_key = api_key.strip()
 
     "Get all projects under the team account"
-    def listProjects(self, query: dict = {}) -> Tuple[dict, dict]:
+    def listProjects(self, query: dict = {}) -> dict:
         return self.__call("GET", "projects", query)
 
     "Get a specific project by ID"
-    def getProject(self, project_id: str, query: dict = {}) -> Tuple[dict, dict]:
+    def getProject(self, project_id: str, query: dict = {}) -> dict:
         return self.__call("GET", f"projects/{project_id}", query)
     
     "Update a project's settings"
-    def updateProject(self, project_id: str, json: dict = {}) -> Tuple[dict, dict]:
+    def updateProject(self, project_id: str, json: dict = {}) -> dict:
         return self.__call("PUT", f"projects/{project_id}", json)
 
-    def __call(self, method: str, route: str, data: dict = {}) -> Tuple[dict, dict]:
+    def __call(self, method: str, route: str, data: dict = {}) -> dict:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
@@ -31,11 +30,12 @@ class API():
 
         if method == "POST":
             res = requests.post(endpoint, json=data, headers=headers)
+        elif method == "PUT":
+            res = requests.put(endpoint, json=data, headers=headers)
         elif method == "GET":
             res = requests.get(endpoint, params=data, headers=headers)
 
-        meta = {"headers":res.headers}
         try:
-            return res.json(), meta
+            return res.json()
         except:
-            return {}, meta
+            return {}

--- a/banana_dev/api.py
+++ b/banana_dev/api.py
@@ -1,34 +1,23 @@
 from typing import Union, Tuple
 import requests
 
-API_BASE_URL = "https://api.banana.dev/v1"
-
 
 class API():
     "The Banana API class interacts with the Banana API."
     def __init__(self, api_key):
-        self.api_key = api_key
-
-    "Get the projects API client"
-    def projects(self) -> "ProjectsAPI":
-        return ProjectsAPI(self.api_key)
-
-
-class ProjectsAPI():
-    "The Banana Projects API class is for interacting with Banana's API for project automation."
-    def __init__(self, api_key,):
+        self.base_url = "https://api.banana.dev/v1"
         self.api_key = api_key
 
     "Get all projects under the team account"
-    def list(self, route: str, json: dict = {}) -> Tuple[dict, dict]:
-        return self.__call("GET", route, json)
+    def listProjects(self, query: dict = {}) -> Tuple[dict, dict]:
+        return self.__call("GET", "projects", query)
 
     "Get a specific project by ID"
-    def get(self, project_id: str) -> Tuple[dict, dict]:
-        return self.__call("GET", f"projects/{project_id}")
+    def getProject(self, project_id: str, query: dict = {}) -> Tuple[dict, dict]:
+        return self.__call("GET", f"projects/{project_id}", query)
     
     "Update a project's settings"
-    def update(self, project_id: str, json: dict = {}) -> Tuple[dict, dict]:
+    def updateProject(self, project_id: str, json: dict = {}) -> Tuple[dict, dict]:
         return self.__call("PUT", f"projects/{project_id}", json)
 
     def __call(self, method: str, route: str, data: dict = {}) -> Tuple[dict, dict]:
@@ -38,12 +27,12 @@ class ProjectsAPI():
             "X-BANANA-API-KEY": self.api_key
         }
 
-        endpoint = f"{API_BASE_URL}/{route}"
+        endpoint = f"{self.base_url}/{route}"
 
         if method == "POST":
             res = requests.post(endpoint, json=data, headers=headers)
         elif method == "GET":
-            res = requests.get(endpoint, headers=headers)
+            res = requests.get(endpoint, params=data, headers=headers)
 
         meta = {"headers":res.headers}
         try:

--- a/banana_dev/client.py
+++ b/banana_dev/client.py
@@ -13,7 +13,7 @@ class ClientException(Exception):
         super().__init__(self.message)
 
 class Client():
-    "The Banana client class is for interracting with a specific project on Banana."
+    "The Banana client class is for interacting with a specific project on Banana."
     def __init__(self, api_key, url, verbosity = "DEBUG"):
         self.api_key = api_key
         self.url = url

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,4 @@
-!#/bin/bash
+#!/bin/bash
+
 python3 setup.py sdist bdist_wheel
 python3 -m twine upload dist/* --skip-existing

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='banana_dev',
     packages=['banana_dev'],
-    version='6.1.0',
+    version='6.2.0',
     license='MIT',
     # Give a short description about your library
     description='The banana package is a python client to interact with your machine learning models hosted on Banana',


### PR DESCRIPTION
# What is this?

Provides access to the [Banana API](https://docs.api.banana.dev) natively in the SDK.

Closes BAN-401

# Why?

A few less steps required for devs to interact with Banana ecosystem.

# Testing

<img width="1367" alt="image" src="https://github.com/bananaml/banana-python-sdk/assets/6206742/f2f1c89f-b127-45cd-8c7c-422dd649be6d">